### PR TITLE
removed fs-plus

### DIFF
--- a/lib/archive-editor-view.js
+++ b/lib/archive-editor-view.js
@@ -1,7 +1,7 @@
 /** @babel */
 /** @jsx etch.dom */
 
-import fs from 'fs-plus'
+import fs from 'fs'
 import humanize from 'humanize-plus'
 import archive from 'ls-archive'
 import {CompositeDisposable, Disposable, Emitter, File} from 'atom'
@@ -159,7 +159,12 @@ export default class ArchiveEditorView {
     const directoryLabel = directoryCount === 1 ? '1 folder' : `${humanize.intComma(directoryCount)} folders`
 
     this.refs.summary.style.display = ''
-    this.refs.summary.textContent = `${humanize.fileSize(fs.getSizeSync(this.path))} with ${fileLabel} and ${directoryLabel}`
+    let fileSize
+    try {
+      fileSize = fs.statSync(this.path)?.size;
+    } catch (e) {}
+    if (fileSize == null) fileSize = -1
+    this.refs.summary.textContent = `${humanize.fileSize(fileSize)} with ${fileLabel} and ${directoryLabel}`
   }
 
   focusSelectedFile () {

--- a/lib/archive-editor.js
+++ b/lib/archive-editor.js
@@ -1,4 +1,4 @@
-const fs = require('fs-plus')
+const fs = require('fs')
 const path = require('path')
 const {Disposable} = require('atom')
 
@@ -9,7 +9,12 @@ module.exports = {
   activate () {
     this.disposable = atom.workspace.addOpener((filePath = '') => {
       // Check that filePath exists before opening, in case a remote URI was given
-      if (isPathSupported(filePath) && fs.isFileSync(filePath)) {
+      if (!isPathSupported(filePath)) return;
+      let isFile = false
+      try {
+        isFile = fs.statSync(filePath)?.isFile()
+      } catch (e) {}
+      if (isFile) {
         return new ArchiveEditorView(filePath)
       }
     })
@@ -35,7 +40,11 @@ module.exports = {
   },
 
   deserialize (params = {}) {
-    if (fs.isFileSync(params.path)) {
+    let isFile = false
+    try {
+      isFile = fs.statSync(params.path)?.isFile()
+    } catch (e) {}
+    if (isFile) {
       return new ArchiveEditorView(params.path)
     } else {
       console.warn(`Can't build ArchiveEditorView for path "${params.path}"; file no longer exists`)

--- a/lib/default-file-icons.js
+++ b/lib/default-file-icons.js
@@ -1,25 +1,35 @@
-const fs = require('fs-plus')
+const fs = require('fs')
 const path = require('path')
 
 class DefaultFileIcons {
   iconClassForPath (filePath) {
-    const extension = path.extname(filePath)
+    const extension = path.extname(filePath).toLowerCase()
+    const base = path.basename(filePath, extension).toLowerCase();
 
-    if (fs.isSymbolicLinkSync(filePath)) {
-      return 'icon-file-symlink-file'
-    } else if (fs.isReadmePath(filePath)) {
+    let isSymbolicLinkSync = false
+    try {
+      fs.lstatSync(filePath)?.isSymbolicLink();
+    } catch (e) {}
+    if (isSymbolicLinkSync) return 'icon-file-symlink-file'
+
+    if (base === 'readme' && ['','.markdown','.md','.mdown','.mkd','.mkdown','.rmd','.ron'].includes(extension)) {
       return 'icon-book'
-    } else if (fs.isCompressedExtension(extension)) {
-      return 'icon-file-zip'
-    } else if (fs.isImageExtension(extension)) {
-      return 'icon-file-media'
-    } else if (fs.isPdfExtension(extension)) {
-      return 'icon-file-pdf'
-    } else if (fs.isBinaryExtension(extension)) {
-      return 'icon-file-binary'
-    } else {
-      return 'icon-file-text'
     }
+
+    if (['.bz2','.egg','.epub','.gem','.gz','.jar','.lz','.lzma','.lzo','.rar','.tar','.tgz','.war','.whl','.xpi','.xz','.z','.zip'].includes(extension)) {
+      return 'icon-file-zip'
+    }
+
+    if (['.gif','.ico','.jpeg','.jpg','.png','.tif','.tiff','.webp'].includes(extension)) {
+      return 'icon-file-media'
+    }
+
+    if (extension === ".pdf") return 'icon-file-pdf'
+
+    if (['.ds_store','.a','.exe','.o','.pyc','.pyo','.so','.woff'].includes(extension)) {
+      return 'icon-file-binary'
+    }
+    return 'icon-file-text'
   }
 }
 

--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -76,7 +76,7 @@ export default class FileView {
             this.logError(`Error creating temp directory: ${tempDirPath}`, error)
           } else {
             const tempArchiveDirPath = path.join(tempDirPath, path.basename(this.archivePath))
-            fs.mkdir(p, {recursive:true}, error => {
+            fs.mkdir(tempArchiveDirPath, {recursive:true}, error => {
               if (error != null) {
                 this.logError(`Error creating archive directory ${tempArchiveDirPath}`, error)
               } else {

--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -2,9 +2,10 @@
 
 import {CompositeDisposable, Disposable} from 'atom'
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs'
 import temp from 'temp'
 import archive from 'ls-archive'
+import mkdirp from 'mkdirp'
 
 import getIconServices from './get-icon-services'
 
@@ -75,12 +76,19 @@ export default class FileView {
           if (error != null) {
             this.logError(`Error creating temp directory: ${tempDirPath}`, error)
           } else {
-            const tempFilePath = path.join(tempDirPath, path.basename(this.archivePath), this.entry.getName())
-            fs.writeFile(tempFilePath, contents, error => {
+            const tempArchiveDirPath = path.join(tempDirPath, path.basename(this.archivePath))
+            mkdirp(tempArchiveDirPath, error => {
               if (error != null) {
-                return this.logError(`Error writing to ${tempFilePath}`, error)
+                this.logError(`Error creating archive directory ${tempArchiveDirPath}`, error)
               } else {
-                return atom.workspace.open(tempFilePath)
+                const tempFilePath = path.join(tempArchiveDirPath, this.entry.getName())
+                fs.writeFile(tempFilePath, contents, error => {
+                  if (error != null) {
+                    this.logError(`Error writing to ${tempFilePath}`, error)
+                  } else {
+                    atom.workspace.open(tempFilePath)
+                  }
+                })
               }
             })
           }

--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -5,7 +5,6 @@ import path from 'path'
 import fs from 'fs'
 import temp from 'temp'
 import archive from 'ls-archive'
-import mkdirp from 'mkdirp'
 
 import getIconServices from './get-icon-services'
 
@@ -77,7 +76,7 @@ export default class FileView {
             this.logError(`Error creating temp directory: ${tempDirPath}`, error)
           } else {
             const tempArchiveDirPath = path.join(tempDirPath, path.basename(this.archivePath))
-            mkdirp(tempArchiveDirPath, error => {
+            fs.mkdir(p, {recursive:true}, error => {
               if (error != null) {
                 this.logError(`Error creating archive directory ${tempArchiveDirPath}`, error)
               } else {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./lib/archive-editor",
   "dependencies": {
     "etch": "0.9.0",
-    "mkdirp": "^0.5.1",
     "humanize-plus": "~1.8.2",
     "ls-archive": "1.3.4",
     "temp": "~0.8.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/archive-editor",
   "dependencies": {
     "etch": "0.9.0",
-    "fs-plus": "^3.0.0",
+    "mkdirp": "^0.5.1",
     "humanize-plus": "~1.8.2",
     "ls-archive": "1.3.4",
     "temp": "~0.8.1"


### PR DESCRIPTION
This pull request removes the `fs-plus` package from the dependencies.

I would like help to make the change in `lib/default-file-icons.js` less specific. It would be nice to use functions from pulsar to determine the file type to allow customization.