### PR TITLE
fix ls-archive link

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "etch": "0.9.0",
     "humanize-plus": "~1.8.2",
-    "ls-archive": "https://github.com/pulsar-edit/node-ls-archive/legacy.tar.gz/refs/tags/v1.4.0.tar.gz",
+    "ls-archive": "https://codeload.github.com/pulsar-edit/node-ls-archive/legacy.tar.gz/refs/tags/v1.3.1",
     "temp": "~0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the ling to the `ls-archive` dependency. It is based on links I saw in the `package.json` from plusar and worked for me locally.